### PR TITLE
BLAIS5-3266: Handle newline in Slack alert titles

### DIFF
--- a/lib/slack/slack_message.py
+++ b/lib/slack/slack_message.py
@@ -41,7 +41,13 @@ def create_from_processed_log_entry(
     )
 
     message_lines = processed_log_entry.message.split("\n")
-    title = message_lines[0]
+    title = f"{processed_log_entry.severity or 'UNKNOWN'}: {message_lines[0]}"
+
+    full_message = processed_log_entry.message if len(message_lines) > 1 else None
+
+    if len(title) > 150:
+        title = f"{title[:145]}..."
+        full_message = processed_log_entry.message
 
     content = (
         processed_log_entry.data
@@ -49,7 +55,7 @@ def create_from_processed_log_entry(
         else json.dumps(processed_log_entry.data, indent=2)
     )
 
-    if len(message_lines) > 1:
+    if full_message:
         content = (
             "**Error Message**\n"
             f"{processed_log_entry.message}\n"
@@ -59,7 +65,7 @@ def create_from_processed_log_entry(
         )
 
     return SlackMessage(
-        title=f"{processed_log_entry.severity or 'UNKNOWN'}: {title}",
+        title=title,
         fields=dict(
             Platform=processed_log_entry.platform or "unknown",
             Application=processed_log_entry.application or "unknown",

--- a/lib/slack/slack_message.py
+++ b/lib/slack/slack_message.py
@@ -40,14 +40,26 @@ def create_from_processed_log_entry(
         else "3. Determine the cause of the error"
     )
 
+    message_lines = processed_log_entry.message.split("\n")
+    title = message_lines[0]
+
     content = (
         processed_log_entry.data
         if isinstance(processed_log_entry.data, str)
         else json.dumps(processed_log_entry.data, indent=2)
     )
 
+    if len(message_lines) > 1:
+        content = (
+            "**Error Message**\n"
+            f"{processed_log_entry.message}\n"
+            "\n"
+            "**Extra Content**\n"
+            f"{content}"
+        )
+
     return SlackMessage(
-        title=f"{processed_log_entry.severity or 'UNKNOWN'}: {processed_log_entry.message}",
+        title=f"{processed_log_entry.severity or 'UNKNOWN'}: {title}",
         fields=dict(
             Platform=processed_log_entry.platform or "unknown",
             Application=processed_log_entry.application or "unknown",

--- a/tests/lib/slack/test_slack_message.py
+++ b/tests/lib/slack/test_slack_message.py
@@ -1,0 +1,90 @@
+from dataclasses import replace
+
+import pytest
+
+from lib.log_processor import ProcessedLogEntry
+from lib.slack.slack_message import create_from_processed_log_entry, SlackMessage
+
+
+@pytest.fixture
+def processed_log_entry() -> ProcessedLogEntry:
+    return ProcessedLogEntry(
+        message="Example error",
+        data={"example_field": "example value"},
+        severity="ERROR",
+        platform="cloud_functions",
+        application="my-app",
+        log_name="/log/my-log",
+        timestamp="2022-08-10T14:54:03.318939Z",
+    )
+
+
+def test_create_from_processed_log_entry(processed_log_entry):
+    message = create_from_processed_log_entry(
+        processed_log_entry, project_name="example-gcp-project"
+    )
+
+    assert message == SlackMessage(
+        title="ERROR: Example error",
+        fields=dict(
+            Platform="cloud_functions",
+            Application="my-app",
+            Project="example-gcp-project",
+        ),
+        content='{\n  "example_field": "example value"\n}',
+        footnote=(
+            "*Next Steps*\n"
+            "1. Add some :eyes: to show you are investigating\n"
+            "2. <https://console.cloud.google.com/monitoring/uptime?referrer=search&project=example-gcp-project | Check the system is online>\n"
+            "3. <https://console.cloud.google.com/logs/query;query=%0A;cursorTimestamp=2022-08-10T14:54:03.318939Z?referrer=search&project=example-gcp-project | View the logs>\n"
+            "4. Follow the <https://confluence.ons.gov.uk/pages/viewpage.action?pageId=98502389 | Managing Prod Alerts> process"
+        ),
+    )
+
+
+def test_create_from_processed_log_with_string_data(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(processed_log_entry, data="This data is a string"),
+        project_name="example-gcp-project",
+    )
+
+    assert message.content == "This data is a string"
+
+
+def test_create_from_processed_log_with_no_severity(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(processed_log_entry, severity=None), project_name="example-gcp-project"
+    )
+
+    assert message.title == "UNKNOWN: Example error"
+
+
+def test_create_from_processed_log_with_no_platform(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(processed_log_entry, platform=None), project_name="example-gcp-project"
+    )
+
+    assert message.fields["Platform"] == "unknown"
+
+
+def test_create_from_processed_log_with_no_application(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(processed_log_entry, application=None),
+        project_name="example-gcp-project",
+    )
+
+    assert message.fields["Application"] == "unknown"
+
+
+def test_create_from_processed_log_with_no_timestamp(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(processed_log_entry, timestamp=None), project_name="example-gcp-project"
+    )
+
+    assert message.footnote == (
+        "*Next Steps*\n"
+        "1. Add some :eyes: to show you are investigating\n"
+        "2. <https://console.cloud.google.com/monitoring/uptime?referrer=search&project=example-gcp-project | Check the system is online>\n"
+        "3. Determine the cause of the error\n"
+        "4. Follow the <https://confluence.ons.gov.uk/pages/viewpage.action?pageId=98502389 | Managing Prod Alerts> process"
+    )

--- a/tests/lib/slack/test_slack_message.py
+++ b/tests/lib/slack/test_slack_message.py
@@ -90,10 +90,16 @@ def test_create_from_processed_log_with_no_timestamp(processed_log_entry):
     )
 
 
-def test_create_from_processed_log_with_message_containing_newlines(processed_log_entry):
+def test_create_from_processed_log_with_message_containing_newlines(
+    processed_log_entry,
+):
     message = create_from_processed_log_entry(
-        replace(processed_log_entry, message="An error occurred\nIt was a terrible error", data="Extra content"),
-        project_name="example-gcp-project"
+        replace(
+            processed_log_entry,
+            message="An error occurred\nIt was a terrible error",
+            data="Extra content",
+        ),
+        project_name="example-gcp-project",
     )
 
     assert message.title == "ERROR: An error occurred"
@@ -101,6 +107,34 @@ def test_create_from_processed_log_with_message_containing_newlines(processed_lo
         "**Error Message**\n"
         "An error occurred\n"
         "It was a terrible error\n"
+        "\n"
+        "**Extra Content**\n"
+        "Extra content"
+    )
+
+
+def test_create_from_processed_log_with_titles_over_150_characters(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(
+            processed_log_entry,
+            message=(
+                "This message creates a title over 150 characters long when combined with the severity "
+                "because it is really really really really really really long"
+            ),
+            severity="ERROR",
+            data="Extra content",
+        ),
+        project_name="example-gcp-project",
+    )
+
+    assert message.title == (
+        "ERROR: This message creates a title over 150 characters long when combined with the severity "
+        "because it is really really really really really rea..."
+    )
+    assert message.content == (
+        "**Error Message**\n"
+        "This message creates a title over 150 characters long when combined with the "
+        "severity because it is really really really really really really long\n"
         "\n"
         "**Extra Content**\n"
         "Extra content"

--- a/tests/lib/slack/test_slack_message.py
+++ b/tests/lib/slack/test_slack_message.py
@@ -88,3 +88,20 @@ def test_create_from_processed_log_with_no_timestamp(processed_log_entry):
         "3. Determine the cause of the error\n"
         "4. Follow the <https://confluence.ons.gov.uk/pages/viewpage.action?pageId=98502389 | Managing Prod Alerts> process"
     )
+
+
+def test_create_from_processed_log_with_message_containing_newlines(processed_log_entry):
+    message = create_from_processed_log_entry(
+        replace(processed_log_entry, message="An error occurred\nIt was a terrible error", data="Extra content"),
+        project_name="example-gcp-project"
+    )
+
+    assert message.title == "ERROR: An error occurred"
+    assert message.content == (
+        "**Error Message**\n"
+        "An error occurred\n"
+        "It was a terrible error\n"
+        "\n"
+        "**Extra Content**\n"
+        "Extra content"
+    )


### PR DESCRIPTION
### Acceptance Criteria
- [x] Alert headers never contain a newline
- [x] Alert headers are limited to 150 characters
- [x] If headers are truncated then they are included in the message body

### Changes
- test: Add tests create_from_processed_log_entry
- feat: Use only the first line of the message in alert titles
- feat: Limit alert titles to 150 characters
