### PR TITLE
BLAIS5-3268: Make Slack alerter get error titles for logs which do not have a line field

### DIFF
--- a/lib/log_processor/log_types/gae_app.py
+++ b/lib/log_processor/log_types/gae_app.py
@@ -16,16 +16,20 @@ def attempt_create(entry: LogEntry) -> Optional[AppLogPayload]:
         message = entry.payload
     else:
         data = copy(entry.payload)
-        data.pop("line", None)
+
         data.pop("moduleId", None)
 
-        if (
+        if "message" in entry.payload:
+            data.pop("message", None)
+            message = entry.payload["message"]
+        elif (
             "line" in entry.payload
             and isinstance(entry.payload["line"], list)
             and len(entry.payload["line"]) > 0
             and isinstance(entry.payload["line"][0], dict)
             and "logMessage" in entry.payload["line"][0]
         ):
+            data.pop("line", None)
             message = entry.payload["line"][0]["logMessage"]
 
     return AppLogPayload(


### PR DESCRIPTION
### Acceptance Criteria
- [x] If "message" is present then it is used as the title.
- [x] If "message" and "line" is present, message is used.
- [x] If "message" is not present, existing logic is used.

Refs: BLAIS5-3268
