### PR TITLE
BLAIS5-3284: Limit the length of the slack alerted message content

### DIFF
--- a/lib/slack/slack_message.py
+++ b/lib/slack/slack_message.py
@@ -64,6 +64,9 @@ def create_from_processed_log_entry(
             f"{content}"
         )
 
+    if len(content) > 2900:
+        content = f"{content[:2900]}...\n[truncated]"
+
     return SlackMessage(
         title=title,
         fields=dict(

--- a/tests/lib/slack/test_slack_message.py
+++ b/tests/lib/slack/test_slack_message.py
@@ -139,3 +139,41 @@ def test_create_from_processed_log_with_titles_over_150_characters(processed_log
         "**Extra Content**\n"
         "Extra content"
     )
+
+
+def test_create_from_processed_log_with_content_over_2900_characters(
+    processed_log_entry,
+):
+    message = create_from_processed_log_entry(
+        replace(
+            processed_log_entry,
+            message="Example Title",
+            severity="ERROR",
+            data="X" * 2901,
+        ),
+        project_name="example-gcp-project",
+    )
+
+    assert message.content == (f"{'X' * 2900}...\n[truncated]")
+
+
+def test_create_from_processed_log_with_content_over_2900_characters_with_extra_message(
+    processed_log_entry,
+):
+    message = create_from_processed_log_entry(
+        replace(
+            processed_log_entry,
+            message="Example Title\nAdditional Line",
+            severity="ERROR",
+            data="X" * 2901,
+        ),
+        project_name="example-gcp-project",
+    )
+
+    extra_chars = (
+        "**Error Message**\nExample Title\nAdditional Line\n\n**Extra Content**\n"
+    )
+
+    assert message.content == (
+        f"{extra_chars}{'X' * (2900 - len(extra_chars))}...\n[truncated]"
+    )


### PR DESCRIPTION
## Acceptance Criteria
- [x] Content is truncated at 2,900 characters
- [x] Content has `...` appended to the content
- [x] Content has `[truncated]` added after a newline at the end of the content 

## Commits
- feat: Limit message content length
- refactor: Extract private functions
