### PR TITLE
BLAIS5-3299: Limit the length of Slack alerts

### DIFF
--- a/lib/slack/slack_message.py
+++ b/lib/slack/slack_message.py
@@ -115,7 +115,21 @@ def _get_content(processed_log_entry: ProcessedLogEntry, full_message: Optional[
             f"{content}"
         )
 
-    if len(content) > 2900:
-        content = f"{content[:2900]}...\n[truncated]"
+    content = _trim_number_of_lines(content, max_lines=10)
 
+    content = _trim_length(content, max_chars=2900)
+
+    return content
+
+
+def _trim_number_of_lines(content, max_lines):
+    lines = content.split("\n")
+    if len(lines) > max_lines:
+        content = "\n".join(lines[0 : max_lines - 2]) + "\n" "...\n" "[truncated]"
+    return content
+
+
+def _trim_length(content, max_chars):
+    if len(content) > max_chars:
+        content = f"{content[:max_chars]}...\n[truncated]"
     return content

--- a/tests/lib/slack/test_slack_message.py
+++ b/tests/lib/slack/test_slack_message.py
@@ -157,7 +157,7 @@ def test_create_from_processed_log_with_content_over_2900_characters(
         project_name="example-gcp-project",
     )
 
-    assert message.content == (f"{'X' * 2900}...\n[truncated]")
+    assert message.content == f"{'X' * 2900}...\n[truncated]"
 
 
 def test_create_from_processed_log_with_content_over_2900_characters_with_extra_message(
@@ -179,4 +179,108 @@ def test_create_from_processed_log_with_content_over_2900_characters_with_extra_
 
     assert message.content == (
         f"{extra_chars}{'X' * (2900 - len(extra_chars))}...\n[truncated]"
+    )
+
+
+def test_create_from_processed_log_with_content_with_10_line_(
+    processed_log_entry,
+):
+    message = create_from_processed_log_entry(
+        replace(
+            processed_log_entry,
+            message="Example Title",
+            severity="ERROR",
+            data=(
+                "line1\n"
+                "line2\n"
+                "line3\n"
+                "line4\n"
+                "line5\n"
+                "line6\n"
+                "line7\n"
+                "line8\n"
+                "line9\n"
+                "line10"
+            ),
+        ),
+        project_name="example-gcp-project",
+    )
+
+    assert message.content == (
+        "line1\n"
+        "line2\n"
+        "line3\n"
+        "line4\n"
+        "line5\n"
+        "line6\n"
+        "line7\n"
+        "line8\n"
+        "line9\n"
+        "line10"
+    )
+
+
+def test_create_from_processed_log_with_content_over_10_lines(
+    processed_log_entry,
+):
+    message = create_from_processed_log_entry(
+        replace(
+            processed_log_entry,
+            message="Example Title",
+            severity="ERROR",
+            data=(
+                "line1\n"
+                "line2\n"
+                "line3\n"
+                "line4\n"
+                "line5\n"
+                "line6\n"
+                "line7\n"
+                "line8\n"
+                "line9\n"
+                "line10\n"
+                "line11\n"
+            ),
+        ),
+        project_name="example-gcp-project",
+    )
+
+    assert message.content == (
+        "line1\n"
+        "line2\n"
+        "line3\n"
+        "line4\n"
+        "line5\n"
+        "line6\n"
+        "line7\n"
+        "line8\n"
+        "...\n"
+        "[truncated]"
+    )
+
+
+def test_create_from_processed_log_with_content_over_10_lines_including_extra_content(
+    processed_log_entry,
+):
+    message = create_from_processed_log_entry(
+        replace(
+            processed_log_entry,
+            message="Example Title\nExtra Line",
+            severity="ERROR",
+            data=("line1\n" "line2\n" "line3\n" "line4\n" "line5\n" "line6"),
+        ),
+        project_name="example-gcp-project",
+    )
+
+    assert message.content == (
+        "**Error Message**\n"
+        "Example Title\n"
+        "Extra Line\n"
+        "\n"
+        "**Extra Content**\n"
+        "line1\n"
+        "line2\n"
+        "line3\n"
+        "...\n"
+        "[truncated]"
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,11 +235,8 @@ def test_send_gce_instance_slack_alert(context):
                         '  "event_type": "error",\n'
                         '  "record_number": "6569254",\n'
                         '  "source_name": "Blaise",\n'
-                        '  "string_inserts": [],\n'
-                        '  "time_generated": "2022-08-02 20:06:38 +0100",\n'
-                        '  "time_written": "2022-08-02 20:06:38 +0100",\n'
-                        '  "user": ""\n'
-                        "}"
+                        "...\n"
+                        "[truncated]"
                     ),
                     type="plain_text",
                 ),
@@ -451,32 +448,15 @@ def test_send_app_engine_slack_alert(caplog, log_matching):
             dict(
                 text=dict(
                     text="{\n"
-                    '  "@type": '
-                    '"type.googleapis.com/google.appengine.logging.v1.RequestLog",\n'
+                    '  "@type": "type.googleapis.com/google.appengine.logging.v1.RequestLog",\n'
                     '  "appEngineRelease": "1.9.71",\n'
                     '  "appId": "g~project-name",\n'
                     '  "endTime": "2022-08-03T14:48:46.535746Z",\n'
                     '  "finished": true,\n'
                     '  "first": true,\n'
-                    '  "host": '
-                    '"0.20220803t140821.app-name.project-name.nw.r.appspot.com",\n'
-                    '  "httpVersion": "HTTP/1.1",\n'
-                    '  "instanceId": "45545245342",\n'
-                    '  "ip": "0.1.0.3",\n'
-                    '  "latency": "0.004229s",\n'
-                    '  "method": "GET",\n'
-                    '  "requestId": '
-                    '"5435342543254325423543254325432543252345",\n'
-                    '  "resource": "/_ah/stop",\n'
-                    '  "responseSize": "3013",\n'
-                    '  "spanId": "7842417449535267939",\n'
-                    '  "startTime": "2022-08-03T14:48:46.531517Z",\n'
-                    '  "status": 500,\n'
-                    '  "traceId": "9998776867876876",\n'
-                    '  "traceSampled": true,\n'
-                    '  "urlMapEntry": "<unused>",\n'
-                    '  "versionId": "20220803t140821"\n'
-                    "}",
+                    '  "host": "0.20220803t140821.app-name.project-name.nw.r.appspot.com",\n'
+                    "...\n"
+                    "[truncated]",
                     type="plain_text",
                 ),
                 type="section",


### PR DESCRIPTION
### Acceptance Criteria
- [x] The content of the Slack alerts is limited to 10 lines (some creativity can be applied to decide what those lines include).
- [ ] ~The content of the message is useful.~ (Extracted to [BLAIS5-3307](https://jira.ons.gov.uk/browse/BLAIS5-3307))

Refs: BLAIS5-3299
