### PR TITLE
fix: Include :alert: in message title

### DIFF
--- a/lib/slack/slack_message.py
+++ b/lib/slack/slack_message.py
@@ -95,7 +95,7 @@ def create_from_processed_log_entry(
 def _get_title(processed_log_entry: ProcessedLogEntry) -> Tuple[str, Optional[str]]:
     message_lines = processed_log_entry.message.split("\n")
 
-    title = f"{processed_log_entry.severity or 'UNKNOWN'}: {message_lines[0]}"
+    title = f":alert: {processed_log_entry.severity or 'UNKNOWN'}: {message_lines[0]}"
 
     full_message = processed_log_entry.message if len(message_lines) > 1 else None
 

--- a/lib/slack/slack_message_formatter.py
+++ b/lib/slack/slack_message_formatter.py
@@ -5,7 +5,7 @@ def convert_slack_message_to_blocks(message: SlackMessage) -> dict:
     blocks = [
         dict(
             type="header",
-            text=dict(type="plain_text", text=f":alert: {message.title}"),
+            text=dict(type="plain_text", text=f"{message.title}"),
         ),
         dict(
             type="section",

--- a/tests/lib/slack/test_slack_message.py
+++ b/tests/lib/slack/test_slack_message.py
@@ -27,7 +27,7 @@ def test_create_from_processed_log_entry(processed_log_entry):
     )
 
     assert message == SlackMessage(
-        title="ERROR: Example error",
+        title=":alert: ERROR: Example error",
         fields={
             "Platform": "cloud_functions",
             "Application": "my-app",
@@ -74,7 +74,7 @@ def test_create_from_processed_log_with_no_severity(processed_log_entry):
         replace(processed_log_entry, severity=None), project_name="example-gcp-project"
     )
 
-    assert message.title == "UNKNOWN: Example error"
+    assert message.title == ":alert: UNKNOWN: Example error"
 
 
 def test_create_from_processed_log_with_no_platform(processed_log_entry):
@@ -121,7 +121,7 @@ def test_create_from_processed_log_with_message_containing_newlines(
         project_name="example-gcp-project",
     )
 
-    assert message.title == "ERROR: An error occurred"
+    assert message.title == ":alert: ERROR: An error occurred"
     assert message.content == (
         "**Error Message**\n"
         "An error occurred\n"
@@ -147,8 +147,8 @@ def test_create_from_processed_log_with_titles_over_150_characters(processed_log
     )
 
     assert message.title == (
-        "ERROR: This message creates a title over 150 characters long when combined with the severity "
-        "because it is really really really really really rea..."
+        ":alert: ERROR: This message creates a title over 150 characters long when combined with the severity "
+        "because it is really really really really re..."
     )
     assert message.content == (
         "**Error Message**\n"

--- a/tests/lib/slack/test_slack_message_formatter.py
+++ b/tests/lib/slack/test_slack_message_formatter.py
@@ -32,7 +32,7 @@ def test_successfully_converting_a_message_to_blocks():
     assert blocks == dict(
         blocks=[
             dict(
-                text=dict(text=":alert: hello world", type="plain_text"),
+                text=dict(text="hello world", type="plain_text"),
                 type="header",
             ),
             dict(
@@ -94,7 +94,7 @@ def test_successfully_converting_a_message_to_blocks_with_no_content():
     assert blocks == dict(
         blocks=[
             dict(
-                text=dict(text=":alert: hello world", type="plain_text"),
+                text=dict(text="hello world", type="plain_text"),
                 type="header",
             ),
             dict(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,7 +101,7 @@ def test_send_raw_string_slack_alert(context):
         http_mock.request_history[0].text
     ) == convert_slack_message_to_blocks(
         SlackMessage(
-            title="UNKNOWN: This is a raw string message",
+            title=":alert: UNKNOWN: This is a raw string message",
             fields={
                 "Platform": "unknown",
                 "Application": "unknown",
@@ -174,7 +174,7 @@ def test_send_gce_instance_slack_alert(context):
         http_mock.request_history[0].text
     ) == convert_slack_message_to_blocks(
         SlackMessage(
-            title="ERROR: Error message from VM",
+            title=":alert: ERROR: Error message from VM",
             fields={
                 "Platform": "gce_instance",
                 "Application": "vm-mgmt",
@@ -263,7 +263,7 @@ def test_send_cloud_function_slack_alert(context):
         http_mock.request_history[0].text
     ) == convert_slack_message_to_blocks(
         SlackMessage(
-            title="ERROR: Example error message",
+            title=":alert: ERROR: Example error message",
             fields={
                 "Platform": "cloud_function",
                 "Application": "log-error",
@@ -366,7 +366,7 @@ def test_send_app_engine_slack_alert(caplog, log_matching):
         http_mock.request_history[0].text
     ) == convert_slack_message_to_blocks(
         SlackMessage(
-            title="ERROR: Example GAE Error",
+            title=":alert: ERROR: Example GAE Error",
             fields={
                 "Platform": "gae_app",
                 "Application": "app-name",


### PR DESCRIPTION
The alert icon was not being included when limiting the title length.
