### PR TITLE
BLAIS5-3705: temporarily silence OSConfigAgent context deadline exceeded errors

### DIFF
--- a/lib/filters/osconfig_agent_filter.py
+++ b/lib/filters/osconfig_agent_filter.py
@@ -3,22 +3,25 @@ from lib.log_processor import ProcessedLogEntry
 
 def osconfig_agent_filter(log_entry: ProcessedLogEntry):
     entry_data = log_entry.data
+    print(log_entry)
 
     if log_entry.platform != "gce_instance":
         return False
 
-    if (
+    # TODO: Remove after BLAIS5-3705 concludes
+    if (log_entry.message and "context deadline exceeded" in log_entry.message) or (
         type(entry_data) is dict
         and "description" in entry_data
         and "OSConfigAgent Error" in entry_data["description"]
-        and "unexpected end of JSON input" in entry_data["description"]
+        and "context deadline exceeded" in entry_data["description"]
     ):
         return True
 
     if (
         type(entry_data) is dict
         and "description" in entry_data
-        and "context deadline exceeded" in entry_data["description"]
+        and "OSConfigAgent Error" in entry_data["description"]
+        and "unexpected end of JSON input" in entry_data["description"]
     ):
         return True
 

--- a/lib/filters/osconfig_agent_filter.py
+++ b/lib/filters/osconfig_agent_filter.py
@@ -8,7 +8,7 @@ def osconfig_agent_filter(log_entry: ProcessedLogEntry):
     if log_entry.platform != "gce_instance":
         return False
 
-    # TODO: Remove after BLAIS5-3705 concludes
+    # TODO: Review after BLAIS5-3705 concludes
     if (log_entry.message and "context deadline exceeded" in log_entry.message) or (
         type(entry_data) is dict
         and "description" in entry_data

--- a/tests/lib/filters/test_osconfig_agent_filter.py
+++ b/tests/lib/filters/test_osconfig_agent_filter.py
@@ -24,6 +24,7 @@ def processed_log_entry_unexpected_end_of_json() -> ProcessedLogEntry:
         },
     )
 
+
 # TODO: Review after BLAIS5-3705 concludes
 @pytest.fixture()
 def processed_log_entry_context_deadline_exceeded() -> ProcessedLogEntry:

--- a/tests/lib/filters/test_osconfig_agent_filter.py
+++ b/tests/lib/filters/test_osconfig_agent_filter.py
@@ -28,10 +28,8 @@ def processed_log_entry_unexpected_end_of_json() -> ProcessedLogEntry:
 @pytest.fixture()
 def processed_log_entry_context_deadline_exceeded() -> ProcessedLogEntry:
     return ProcessedLogEntry(
-        message="OSConfigAgent Error main.go:88: context deadline exceeded",
-        data=dict(
-            description="2023-02-25T03:46:49.1619Z OSConfigAgent Error main.go:88: context deadline exceeded\r\n"
-        ),
+        message="Error: context deadline exceeded",
+        data=dict(omitempty="null", localTimestamp="2023-03-30T16:12:02.8996+01:00"),
         severity="ERROR",
         platform="gce_instance",
         application="blaise-gusty-data-entry-1",

--- a/tests/lib/filters/test_osconfig_agent_filter.py
+++ b/tests/lib/filters/test_osconfig_agent_filter.py
@@ -24,7 +24,7 @@ def processed_log_entry_unexpected_end_of_json() -> ProcessedLogEntry:
         },
     )
 
-
+# TODO: Review after BLAIS5-3705 concludes
 @pytest.fixture()
 def processed_log_entry_context_deadline_exceeded() -> ProcessedLogEntry:
     return ProcessedLogEntry(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -479,7 +479,7 @@ def test_skip_data_delivery_json_error(run_slack_alerter, number_of_http_calls):
     assert number_of_http_calls() == 0
 
 
-# TODO: Remove after BLAIS5-3705 concludes
+# TODO: Review after BLAIS5-3705 concludes
 def test_skip_osconfig_context_deadline_error(run_slack_alerter, number_of_http_calls):
     example_log_entry = {
         "insertId": "yoaqxbe4xao6uzfo3",
@@ -522,7 +522,7 @@ def test_skip_osconfig_context_deadline_error(run_slack_alerter, number_of_http_
     assert number_of_http_calls() == 0
 
 
-# TODO: Remove after BLAIS5-3705 concludes
+# TODO: Review after BLAIS5-3705 concludes
 def test_skip_context_deadline_error(run_slack_alerter, number_of_http_calls):
     example_log_entry = {
         "insertId": "1k1vvkyg14nxlhg",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -477,3 +477,82 @@ def test_skip_data_delivery_json_error(run_slack_alerter, number_of_http_calls):
 
     assert response == "Alert skipped"
     assert number_of_http_calls() == 0
+
+
+# TODO: Remove after BLAIS5-3705 concludes
+def test_skip_osconfig_context_deadline_error(run_slack_alerter, number_of_http_calls):
+    example_log_entry = {
+        "insertId": "yoaqxbe4xao6uzfo3",
+        "jsonPayload": {
+            "source_name": "OSConfigAgent",
+            "description": "2023-03-30T16:12:02.8996+01:00 OSConfigAgent Error main.go:88: context deadline exceeded\r\n",
+            "event_category": "0",
+            "record_number": "2003189",
+            "event_id": "882",
+            "time_written": "2023-03-30 16:12:02 +0100",
+            "user": "",
+            "time_generated": "2023-03-30 16:12:02 +0100",
+            "event_type": "error",
+            "string_inserts": [
+                "2023-03-30T16:12:02.8996+01:00 OSConfigAgent Error main.go:88: context deadline exceeded"
+            ],
+            "channel": "application",
+            "message": "2023-03-30T16:12:02.8996+01:00 OSConfigAgent Error main.go:88: context deadline exceeded\r\n",
+            "computer_name": "restapi-1",
+        },
+        "resource": {
+            "type": "gce_instance",
+            "labels": {
+                "project_id": "ons-blaise-v2-dev",
+                "instance_id": "2017269846350558215",
+                "zone": "europe-west2-a",
+            },
+        },
+        "timestamp": "2023-03-30T15:12:02Z",
+        "severity": "ERROR",
+        "labels": {"compute.googleapis.com/resource_name": "restapi-1"},
+        "logName": "projects/ons-blaise-v2-dev/logs/winevt.raw",
+        "receiveTimestamp": "2023-03-30T15:12:07.299339599Z",
+    }
+    event = create_event(example_log_entry)
+
+    response = run_slack_alerter(event)
+
+    assert response == "Alert skipped"
+    assert number_of_http_calls() == 0
+
+
+# TODO: Remove after BLAIS5-3705 concludes
+def test_skip_context_deadline_error(run_slack_alerter, number_of_http_calls):
+    example_log_entry = {
+        "insertId": "1k1vvkyg14nxlhg",
+        "jsonPayload": {
+            "omitempty": "null",
+            "message": "context deadline exceeded",
+            "localTimestamp": "2023-03-30T16:12:02.8996+01:00",
+        },
+        "resource": {
+            "type": "gce_instance",
+            "labels": {
+                "project_id": "ons-blaise-v2-dev",
+                "instance_id": "2017269846350558215",
+                "zone": "europe-west2-a",
+            },
+        },
+        "timestamp": "2023-03-30T15:12:02.940142100Z",
+        "severity": "ERROR",
+        "labels": {"instance_name": "restapi-1"},
+        "logName": "projects/ons-blaise-v2-dev/logs/OSConfigAgent",
+        "sourceLocation": {
+            "file": "main.go",
+            "line": "88",
+            "function": "main.registerAgent",
+        },
+        "receiveTimestamp": "2023-03-30T15:12:03.960254682Z",
+    }
+    event = create_event(example_log_entry)
+
+    response = run_slack_alerter(event)
+
+    assert response == "Alert skipped"
+    assert number_of_http_calls() == 0


### PR DESCRIPTION
Structure of the plain "context deadline exceeded" error after being processed:
`ProcessedLogEntry(
message='context deadline exceeded', 
data={'omitempty': 'null', 'localTimestamp': '2023-03-30T16:12:02.8996+01:00'}, severity='ERROR', platform='gce_instance', application='restapi-1', log_name='projects/ons-blaise-v2-dev/logs/OSConfigAgent', timestamp=datetime.datetime(2023, 3, 30, 15, 12, 3, 960254, tzinfo=tzutc()), log_query={'resource.type': 'gce_instance', 'resource.labels.instance_id': '2017269846350558215'}, 
most_important_values=['description', 'event_type']
)`

Structure of the "OSConfigAgent Error: context deadline exceeded" after being processed:
`ProcessedLogEntry(
message='2023-03-30T16:12:02.8996+01:00 OSConfigAgent Error main.go:88: context deadline exceeded\r\n', 
data={'source_name': 'OSConfigAgent', 'description': '2023-03-30T16:12:02.8996+01:00 OSConfigAgent Error main.go:88: context deadline exceeded\r\n', 'event_category': '0', 'record_number': '2003189', 'event_id': '882', 'time_written': '2023-03-30 16:12:02 +0100', 'user': '', 'time_generated': '2023-03-30 16:12:02 +0100', 'event_type': 'error', 'string_inserts': ['2023-03-30T16:12:02.8996+01:00 OSConfigAgent Error main.go:88: context deadline exceeded'], 'channel': 'application'}, severity='ERROR', platform='gce_instance', application='restapi-1', log_name='projects/ons-blaise-v2-dev/logs/winevt.raw', timestamp=datetime.datetime(2023, 3, 30, 15, 12, 7, 299339, tzinfo=tzutc()), log_query={'resource.type': 'gce_instance', 'resource.labels.instance_id': '2017269846350558215'}, most_important_values=['description', 'event_type']
)`

This change should filter out both "context deadline exceeded" logs (there are two integration tests in `test_main.py`, one for each)